### PR TITLE
fix: audio output has correct spacing

### DIFF
--- a/pynfogen/nfo.py
+++ b/pynfogen/nfo.py
@@ -218,7 +218,7 @@ class NFO:
         data = []
         for a in audio:
             data.append(CustomFormats().vformat(
-                "- <?{language:true}?{language}, ?><?{title:true}?, {title}?>, {codec} {channels} @ "
+                "- <?{language:true}?{language}, ?><?{title:true}? {title}, ?>{codec} {channels} @ "
                 "{bitrate}<?{bit_rate_mode:true}? ({bit_rate_mode})?>",
                 args=[],
                 kwargs=a.all_properties


### PR DESCRIPTION
Fix below
``` 
  - English, , DD 5.1 @ 640 kb/s (CBR)
```
to
```
  - English, DD 5.1 @ 640 kb/s (CBR)
```
