### PR TITLE
fix: pull bitrate only for non-text tracks 

### DIFF
--- a/pynfogen/nfo.py
+++ b/pynfogen/nfo.py
@@ -218,7 +218,7 @@ class NFO:
         data = []
         for a in audio:
             data.append(CustomFormats().vformat(
-                "- <?{language:true}?{language}, ?><?{title:true}?, {title}?>, {codec} {channels} @ "
+                "- <?{language:true}?{language}, ?><?{title:true}? {title}, ?>{codec} {channels} @ "
                 "{bitrate}<?{bit_rate_mode:true}? ({bit_rate_mode})?>",
                 args=[],
                 kwargs=a.all_properties

--- a/pynfogen/tracks/BaseTrack.py
+++ b/pynfogen/tracks/BaseTrack.py
@@ -14,7 +14,7 @@ class BaseTrack:
         self._x = track
         self._path = path
         # common shorthands
-        self.bitrate = self._x.other_bit_rate[0]
+        self.bitrate = self._x.other_bit_rate[0] if self._x.track_type != "Text" else None
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._x, name)


### PR DESCRIPTION
Fixes `NoneType` is not subscriptable for `self.bitrate = self._x.other_bit_rate[0]`